### PR TITLE
Add log fetch to debian.yml

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -30,3 +30,9 @@
   shell: "./stack.sh 2>&1 | tee stack_run.log"
   args:
     chdir: '~/devstack'
+    
+- name: Fetch stack.sh log file
+  fetch:
+    src: ~/devstack/stack_run.log
+    dest: "{{ run_directory }}"/logs/"
+    flat: yes 


### PR DESCRIPTION
It would be nice to receive a log of the stack run, but I'm wondering if the run_directory variable is something you are okay with adding to your role.